### PR TITLE
Add LIDAR maps: terrain and surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,22 @@ http://localhost:8080/tiles/xgis/hidpi/{zoom}/{x}/{y}.png
 
 There are two maps derived from LIDAR surveys.
 
-[<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-01.png)
+| Terrain (DTM) | Surface (DSM) |
+| ------------- | ------------- |
+| [<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-01.png) | [<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01.png) |
 
 Digital Terrain Model (DTM) - represents the bare ground surface without any
 objects like plants and buildings:
 
 * Demo: http://localhost:8080/demo/?tms_layer=xgis_terrain&format=png&srs=EPSG:3857
-* URL for iD editor: `http://localhost:8080/tiles/xgis_terrain/hidpi/{zoom}/{x}/{y}.png`
-
-[<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01.png)
+* URL for iD editor: `http://localhost:8080/tiles/xgis_terrain/normal/{zoom}/{x}/{y}.png`
 
 Digital Surface Model (DSM), overlaid on top of DTM - represents the surface
 with objects like buildings and trees. Note: The surface layer is only visible
 at higher zoom levels.
 
 * Demo: http://localhost:8080/demo/?tms_layer=xgis_surface&format=png&srs=EPSG:3857
-* URL for iD editor: `http://localhost:8080/tiles/xgis_surface/hidpi/{zoom}/{x}/{y}.png`
+* URL for iD editor: `http://localhost:8080/tiles/xgis_surface/normal/{zoom}/{x}/{y}.png`
 
 ### Is this allowed?
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ objects like plants and buildings:
 [<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01.png)
 
 Digital Surface Model (DSM), overlaid on top of DTM - represents the surface
-with objects like buildings and trees:
+with objects like buildings and trees. Note: The surface layer is only visible
+at higher zoom levels.
 
 * Demo: http://localhost:8080/demo/?tms_layer=xgis_surface&format=png&srs=EPSG:3857
 * URL for iD editor: `http://localhost:8080/tiles/xgis_surface/hidpi/{zoom}/{x}/{y}.png`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Click on the "•••" next to "Custom" and enter the following URL:
 http://localhost:8080/tiles/xgis/hidpi/{zoom}/{x}/{y}.png
 ```
 
-#### LIDAR maps
+### LIDAR maps
 
 There are two maps derived from LIDAR surveys.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@ HiStonia
 
 HiStonia is a [MapProxy](https://mapproxy.org/) configuration for serving up
 **high-resolution tiles** from Estonian Maa-amet (Land Board) aerial photo maps,
-which you can use as imagery in the **OpenStreetMap iD editor**.
+and LIDAR maps, which you can use as imagery in the **OpenStreetMap iD editor**.
 
-High-resolution tiles are available from Maa-amet's WMS servers, but
-unfortunately the iD editor only supports the TMS (Tile Map Service) protocol,
-not WMS.
+High-resolution tiles and LIDAR tiles are available from Maa-amet's WMS servers,
+but the iD editor only supports the TMS (Tile Map Service) protocol, not WMS.
 
 This MapProxy configuration provides TMS and converts back and forth between WMS.
 
@@ -35,10 +34,33 @@ Click on the "•••" next to "Custom" and enter the following URL:
 http://localhost:8080/tiles/xgis/hidpi/{zoom}/{x}/{y}.png
 ```
 
+#### LIDAR maps
+
+There are two maps derived from LIDAR surveys.
+
+[<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-01.png)
+
+Digital Terrain Model (DTM) - represents the bare ground surface without any
+objects like plants and buildings:
+
+* Demo: http://localhost:8080/demo/?tms_layer=xgis_terrain&format=png&srs=EPSG:3857
+* URL for iD editor: `http://localhost:8080/tiles/xgis_terrain/hidpi/{zoom}/{x}/{y}.png`
+
+[<img src="https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01-thumb.jpg">](https://raw.githubusercontent.com/intgr/static/master/histonia/histonia-terrain-surface-01.png)
+
+Digital Surface Model (DSM), overlaid on top of DTM - represents the surface
+with objects like buildings and trees:
+
+* Demo: http://localhost:8080/demo/?tms_layer=xgis_surface&format=png&srs=EPSG:3857
+* URL for iD editor: `http://localhost:8080/tiles/xgis_surface/hidpi/{zoom}/{x}/{y}.png`
+
 ### Is this allowed?
 
 Yes, Maa-amet has issued an official permission to OpenStreetMap:
 https://svimik.com/Maa-amet_vastus_OSM.pdf
+
+For non-OpenStreetMap-related uses, see the open data license:
+https://geoportaal.maaamet.ee/docs/Avaandmed/ETAK_ruumiandmete_litsentsileping.pdf
 
 Many public Maa-amet services are documented here:
 https://geoportaal.maaamet.ee/est/Teenused/WMSWFS-teenused-p65.html

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@ HiStonia
 ========
 
 HiStonia is a [MapProxy](https://mapproxy.org/) configuration for serving up
-**high-resolution tiles** from Estonian Maa-amet (Land Board) aerial photo maps,
+**high-resolution tiles** from Estonian Maa-amet (Land Board) aerophoto maps
 and LIDAR maps, which you can use as imagery in the **OpenStreetMap iD editor**.
 
 High-resolution tiles and LIDAR tiles are available from Maa-amet's WMS servers,
 but the iD editor only supports the TMS (Tile Map Service) protocol, not WMS.
 
-This MapProxy configuration provides TMS and converts back and forth between WMS.
+This MapProxy configuration provides a TMS service and converts back and forth
+between WMS.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Digital Terrain Model (DTM) - represents the bare ground surface without any
 objects like plants and buildings:
 
 * Demo: http://localhost:8080/demo/?tms_layer=xgis_terrain&format=png&srs=EPSG:3857
-* URL for iD editor: `http://localhost:8080/tiles/xgis_terrain/normal/{zoom}/{x}/{y}.png`
+* URL for iD editor: `http://localhost:8080/tiles/xgis_terrain/hidpi/{zoom}/{x}/{y}.png`
 
 Digital Surface Model (DSM), overlaid on top of DTM - represents the surface
 with objects like buildings and trees. Note: The surface layer is only visible
 at higher zoom levels.
 
 * Demo: http://localhost:8080/demo/?tms_layer=xgis_surface&format=png&srs=EPSG:3857
-* URL for iD editor: `http://localhost:8080/tiles/xgis_surface/normal/{zoom}/{x}/{y}.png`
+* URL for iD editor: `http://localhost:8080/tiles/xgis_surface/hidpi/{zoom}/{x}/{y}.png`
 
 ### Is this allowed?
 

--- a/mapproxy.yaml
+++ b/mapproxy.yaml
@@ -36,7 +36,7 @@ caches:
     cache:
       type: file
       use_grid_names: true
-    grids: [normal]
+    grids: [hidpi]
     sources: [xgis_wms_terrain]
 
   # DSM (Digital Surface Model) and DTM layers overlaid on top of each other
@@ -44,7 +44,7 @@ caches:
     cache:
       type: file
       use_grid_names: true
-    grids: [normal]
+    grids: [hidpi]
     sources: [xgis_wms_surface]
 
 sources:
@@ -92,7 +92,5 @@ grids:
     base: GLOBAL_WEBMERCATOR
     tile_size: [512, 512]
     num_levels: 22
-  normal:
-    base: GLOBAL_WEBMERCATOR
 
 globals:

--- a/mapproxy.yaml
+++ b/mapproxy.yaml
@@ -14,6 +14,12 @@ layers:
   - name: xgis
     title: Maaamet X-GIS
     sources: [xgis_cache]
+  - name: xgis_terrain
+    title: Maaamet Terrain
+    sources: [xgis_terrain_cache]
+  - name: xgis_surface
+    title: Maaamet Surface
+    sources: [xgis_surface_cache]
 
 caches:
   xgis_cache:
@@ -25,12 +31,57 @@ caches:
     sources: [xgis_wms]
     meta_size: [2, 2]
 
+  # DTM (Digital Terrain Model) only
+  xgis_terrain_cache:
+    cache:
+      type: file
+      use_grid_names: true
+    grids: [hidpi]
+    sources: [xgis_wms_terrain]
+
+  # DSM (Digital Surface Model) and DTM layers overlaid on top of each other
+  xgis_surface_cache:
+    cache:
+      type: file
+      use_grid_names: true
+    grids: [hidpi]
+    sources: [xgis_wms_surface]
+
 sources:
   xgis_wms:
     type: wms
     req:
       url: https://xgis.maaamet.ee/xgis2/service/i6na/mit?
       layers: EESTIFOTO
+    concurrent_requests: 4
+    supported_srs: ["EPSG:3301"]
+    coverage:
+      # Source for bounding box: https://epsg.io/3301
+      bbox: [282560, 6381157, 734255, 6658861]
+      bbox_srs: "EPSG:3301"
+
+  # DTM - Digital Terrain Model - represents the bare ground surface without any objects like plants and buildings
+  xgis_wms_terrain:
+    type: wms
+    req:
+      url: https://xgis.maaamet.ee/xgis2/service/i6na/mit?
+      layers: colormap,HYBRID,colormap_shade
+      transparent: true
+    concurrent_requests: 4
+    supported_srs: ["EPSG:3301"]
+    coverage:
+      # Source for bounding box: https://epsg.io/3301
+      bbox: [282560, 6381157, 734255, 6658861]
+      bbox_srs: "EPSG:3301"
+
+  # nDSM - normalised Digital Surface Model - captures both the natural and built/artificial features of the environment
+  # This is an overlay used on top of DTM.
+  xgis_wms_surface:
+    type: wms
+    req:
+      url: https://xgis.maaamet.ee/xgis2/service/i6na/mit?
+      layers: colormap,HYBRID,colormap_shade,nDSM
+      transparent: true
     concurrent_requests: 4
     supported_srs: ["EPSG:3301"]
     coverage:

--- a/mapproxy.yaml
+++ b/mapproxy.yaml
@@ -36,7 +36,7 @@ caches:
     cache:
       type: file
       use_grid_names: true
-    grids: [hidpi]
+    grids: [normal]
     sources: [xgis_wms_terrain]
 
   # DSM (Digital Surface Model) and DTM layers overlaid on top of each other
@@ -44,7 +44,7 @@ caches:
     cache:
       type: file
       use_grid_names: true
-    grids: [hidpi]
+    grids: [normal]
     sources: [xgis_wms_surface]
 
 sources:
@@ -66,7 +66,6 @@ sources:
     req:
       url: https://xgis.maaamet.ee/xgis2/service/i6na/mit?
       layers: colormap,HYBRID,colormap_shade
-      transparent: true
     concurrent_requests: 4
     supported_srs: ["EPSG:3301"]
     coverage:
@@ -81,7 +80,6 @@ sources:
     req:
       url: https://xgis.maaamet.ee/xgis2/service/i6na/mit?
       layers: colormap,HYBRID,colormap_shade,nDSM
-      transparent: true
     concurrent_requests: 4
     supported_srs: ["EPSG:3301"]
     coverage:
@@ -94,5 +92,7 @@ grids:
     base: GLOBAL_WEBMERCATOR
     tile_size: [512, 512]
     num_levels: 22
+  normal:
+    base: GLOBAL_WEBMERCATOR
 
 globals:


### PR DESCRIPTION
Added two LIDAR-based maps to TMS:
* `xgis_terrain` - Digital Terrain Model (DTM) - represents the bare ground surface without any objects like plants and buildings.
* `xgis_surface` - Digital Surface Model (DSM), overlaid on top of DTM - represents the surface with objects like buildings and trees. Note: The surface layer is only visible at higher zoom levels.

See README for more details.

Closes #1.